### PR TITLE
Clarify --dry-run help text and add test for run help

### DIFF
--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,5 +1,7 @@
 import unittest
 
+import argparse
+
 from tol.cli.main import build_parser
 
 
@@ -32,6 +34,20 @@ class TestCliMain(unittest.TestCase):
         args = parser.parse_args(["run", "example.yaml", "--mode", "paper"])
 
         self.assertEqual(args.dry_run, None)
+
+    def test_run_help_includes_dry_run_intentions(self) -> None:
+        parser = build_parser()
+        subparsers_action = next(
+            action
+            for action in parser._actions
+            if isinstance(action, argparse._SubParsersAction)
+        )
+        run_parser = subparsers_action.choices["run"]
+        help_text = run_parser.format_help()
+
+        self.assertIn("validates the TOL file only", help_text)
+        self.assertIn("queries holdings and prices", help_text)
+        self.assertIn("connects to IBKR", help_text)
 
 
 if __name__ == "__main__":

--- a/tol/cli/main.py
+++ b/tol/cli/main.py
@@ -41,7 +41,10 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["local", "portfolio", "broker"],
         help=(
             "Perform a dry run without executing orders. "
-            "If specified without a value, defaults to 'portfolio'."
+            "If specified without a value, defaults to 'portfolio'. "
+            "Levels: 'local' validates the TOL file only; 'portfolio' also "
+            "queries holdings and prices to compute quantities; 'broker' also "
+            "connects to IBKR to validate order parameters."
         ),
     )
 


### PR DESCRIPTION
### Motivation
- Make the CLI help for the `--dry-run` option explicit about what each level (`local`, `portfolio`, `broker`) actually does so users can choose the intended validation depth.
- Add a unit test to ensure the `run` subcommand help surface includes the clarified dry-run intentions so the documentation remains present and test-covered.

### Description
- Expanded the `--dry-run` help text in `tol/cli/main.py` to describe that `local` validates the TOL file only, `portfolio` also queries holdings and prices to compute quantities, and `broker` connects to IBKR to validate order parameters.
- Added `test_run_help_includes_dry_run_intentions` to `tests/test_cli_main.py` which extracts the `run` subparser help and asserts the new descriptive phrases are present, and added an `import argparse` required by that test.

### Testing
- Ran the test suite with `python -m pytest` and all tests passed (`4 passed`).
- The new test verifies the presence of the expanded help phrases for the `run` subcommand help and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697809538b108321a0e23aedb7d25937)