### PR TITLE
Normalize target percent strings in TOL loader

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+
+from tol.load import load_tol
+
+
+def test_load_converts_all_and_percent(tmp_path: Path) -> None:
+    tol_file = tmp_path / "example.json"
+    tol_file.write_text(
+        """
+{
+  "version": 1,
+  "actions": [
+    {"buy": {"symbol": "TSLA", "quantity": "ALL"}},
+    {"sell": {"symbol": "NVDA", "quantity": "25%"}}
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+
+    tol_doc = load_tol(tol_file)
+    actions = tol_doc["actions"]
+    assert actions[0]["buy"]["quantity"] == 1.0
+    assert actions[1]["sell"]["quantity"] == 0.25
+
+
+def test_load_converts_string_integer(tmp_path: Path) -> None:
+    tol_file = tmp_path / "example.json"
+    tol_file.write_text(
+        """
+{
+  "version": 1,
+  "actions": [
+    {"buy": {"symbol": "TSLA", "quantity": "100"}}
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+
+    tol_doc = load_tol(tol_file)
+    assert tol_doc["actions"][0]["buy"]["quantity"] == 100
+
+
+def test_load_rejects_float_greater_than_one(tmp_path: Path) -> None:
+    tol_file = tmp_path / "example.json"
+    tol_file.write_text(
+        """
+{
+  "version": 1,
+  "actions": [
+    {"buy": {"symbol": "TSLA", "quantity": 1.5}}
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        load_tol(tol_file)
+
+
+def test_load_parses_target_percent_string(tmp_path: Path) -> None:
+    tol_file = tmp_path / "example.json"
+    tol_file.write_text(
+        """
+{
+  "version": 1,
+  "actions": [
+    {"target": {"symbol": "AAPL", "percent": "25%"}}
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+
+    tol_doc = load_tol(tol_file)
+    assert tol_doc["actions"][0]["target"]["percent"] == 25.0

--- a/tests/test_portfolio_dry_run.py
+++ b/tests/test_portfolio_dry_run.py
@@ -1,0 +1,109 @@
+from decimal import Decimal
+import unittest
+
+from tol.cli.handlers.portfolio_dry_run import (
+    build_snapshot,
+    evaluate_actions,
+    normalize_quantity,
+)
+from tol.parser.planner import plan_actions
+
+
+class TestPortfolioDryRun(unittest.TestCase):
+    def test_normalize_quantity(self) -> None:
+        qty_all = normalize_quantity("ALL")
+        self.assertEqual(qty_all.kind, "all")
+
+        qty_percent = normalize_quantity("25%")
+        self.assertEqual(qty_percent.kind, "percent")
+        self.assertEqual(qty_percent.value, Decimal("0.25"))
+
+        qty_shares = normalize_quantity(10)
+        self.assertEqual(qty_shares.kind, "shares")
+        self.assertEqual(qty_shares.value, Decimal("10"))
+
+        qty_float = normalize_quantity(0.5)
+        self.assertEqual(qty_float.kind, "percent")
+        self.assertEqual(qty_float.value, Decimal("0.5"))
+
+    def test_sell_insufficient_holdings(self) -> None:
+        tol_doc = {
+            "actions": [
+                {"sell": {"symbol": "AAPL", "quantity": 10}},
+            ]
+        }
+        actions = plan_actions(tol_doc)
+        snapshot = build_snapshot(
+            {"USD": Decimal("1000")},
+            [
+                {
+                    "symbol": "AAPL",
+                    "quantity": Decimal("5"),
+                    "market_value": Decimal("500"),
+                    "currency": "USD",
+                }
+            ],
+        )
+
+        evaluations = evaluate_actions(actions, snapshot)
+        self.assertTrue(evaluations[0].errors)
+
+    def test_buy_with_cash_sources(self) -> None:
+        tol_doc = {
+            "actions": [
+                {"buy": {"symbol": "MSFT", "quantity": 5, "using": ["CASH"]}},
+            ]
+        }
+        actions = plan_actions(tol_doc)
+        snapshot = build_snapshot(
+            {"USD": Decimal("1000")},
+            [
+                {
+                    "symbol": "MSFT",
+                    "quantity": Decimal("10"),
+                    "market_value": Decimal("1000"),
+                    "currency": "USD",
+                }
+            ],
+        )
+
+        evaluations = evaluate_actions(actions, snapshot)
+        self.assertFalse(evaluations[0].errors)
+        self.assertTrue(
+            any("Estimated spend" in msg for msg in evaluations[0].messages)
+        )
+
+    def test_target_implied_buy(self) -> None:
+        tol_doc = {
+            "actions": [
+                {
+                    "target": {
+                        "symbol": "AAPL",
+                        "percent": 75,
+                        "using": ["CASH", "AAPL"],
+                    }
+                }
+            ]
+        }
+        actions = plan_actions(tol_doc)
+        snapshot = build_snapshot(
+            {"USD": Decimal("1000")},
+            [
+                {
+                    "symbol": "AAPL",
+                    "quantity": Decimal("10"),
+                    "market_value": Decimal("1000"),
+                    "currency": "USD",
+                }
+            ],
+        )
+
+        evaluations = evaluate_actions(actions, snapshot)
+        self.assertFalse(evaluations[0].errors)
+        self.assertTrue(
+            any("Implied buy" in msg for msg in evaluations[0].messages)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tol/cli/handlers/portfolio_dry_run.py
+++ b/tol/cli/handlers/portfolio_dry_run.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Iterable, Optional
+
+from tol.ibkr.gateway import IBKRGateway
+from tol.parser.planner import PlannedAction
+
+
+@dataclass(frozen=True)
+class QuantitySpec:
+    kind: str
+    value: Optional[Decimal] = None
+
+
+@dataclass(frozen=True)
+class PortfolioPosition:
+    symbol: str
+    quantity: Decimal
+    market_value: Decimal
+    currency: str
+
+    @property
+    def price(self) -> Optional[Decimal]:
+        if self.quantity == 0:
+            return None
+        return self.market_value / self.quantity
+
+
+@dataclass(frozen=True)
+class PortfolioSnapshot:
+    cash_by_currency: dict[str, Decimal]
+    positions_by_symbol: dict[str, PortfolioPosition]
+
+    @property
+    def total_cash(self) -> Decimal:
+        return sum(self.cash_by_currency.values(), Decimal("0"))
+
+
+@dataclass
+class ActionEvaluation:
+    action_id: str
+    action_type: str
+    messages: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def normalize_quantity(quantity: object) -> Optional[QuantitySpec]:
+    if quantity is None:
+        return None
+    if isinstance(quantity, QuantitySpec):
+        return quantity
+    if isinstance(quantity, int):
+        return QuantitySpec(kind="shares", value=_coerce_decimal(quantity))
+    if isinstance(quantity, (float, Decimal)):
+        value = _coerce_decimal(quantity)
+        if value > 1:
+            raise ValueError("Float quantity must be <= 1.0 for percentages.")
+        return QuantitySpec(kind="percent", value=value)
+    if isinstance(quantity, str):
+        raw = quantity.strip().upper()
+        if raw == "ALL":
+            return QuantitySpec(kind="all")
+        if raw.endswith("%"):
+            value = raw[:-1].strip()
+            if not value:
+                raise ValueError("Percent quantity is missing a value.")
+            return QuantitySpec(
+                kind="percent",
+                value=_coerce_decimal(value) / Decimal("100"),
+            )
+        return QuantitySpec(kind="shares", value=_coerce_decimal(raw))
+    raise TypeError(f"Unsupported quantity type: {type(quantity).__name__}")
+
+
+def build_snapshot(
+    cash_by_currency: dict[str, Decimal],
+    positions: Iterable[dict[str, Decimal | str]],
+) -> PortfolioSnapshot:
+    positions_by_symbol: dict[str, PortfolioPosition] = {}
+    for position in positions:
+        symbol = str(position["symbol"])
+        positions_by_symbol[symbol] = PortfolioPosition(
+            symbol=symbol,
+            quantity=_coerce_decimal(position["quantity"]),
+            market_value=_coerce_decimal(position["market_value"]),
+            currency=str(position["currency"]),
+        )
+    return PortfolioSnapshot(
+        cash_by_currency={ccy: _coerce_decimal(amt) for ccy, amt in cash_by_currency.items()},
+        positions_by_symbol=positions_by_symbol,
+    )
+
+
+def evaluate_actions(
+    actions: Iterable[PlannedAction],
+    snapshot: PortfolioSnapshot,
+) -> list[ActionEvaluation]:
+    evaluations: list[ActionEvaluation] = []
+    for action in actions:
+        evaluation = ActionEvaluation(
+            action_id=action.derived_id,
+            action_type=action.action_type,
+        )
+        if action.action_type == "sell":
+            _evaluate_sell(action, snapshot, evaluation)
+        elif action.action_type == "buy":
+            _evaluate_buy(action, snapshot, evaluation)
+        elif action.action_type == "target":
+            _evaluate_target(action, snapshot, evaluation)
+        else:
+            evaluation.warnings.append(
+                f"Unknown action type '{action.action_type}'."
+            )
+        evaluations.append(evaluation)
+    return evaluations
+
+
+def build_portfolio_report(
+    snapshot: PortfolioSnapshot,
+    evaluations: Iterable[ActionEvaluation],
+) -> list[str]:
+    lines: list[str] = []
+    lines.append("Portfolio snapshot:")
+    lines.append("Cash:")
+    for ccy in sorted(snapshot.cash_by_currency):
+        amt = snapshot.cash_by_currency[ccy]
+        lines.append(f"  {ccy}: {amt:,.2f}")
+    lines.append("Positions:")
+    for symbol in sorted(snapshot.positions_by_symbol):
+        position = snapshot.positions_by_symbol[symbol]
+        lines.append(
+            f"  {symbol}: {position.quantity} shares "
+            f"(≈ {position.market_value:,.2f} {position.currency})"
+        )
+    lines.append("")
+    lines.append("Dry run evaluation:")
+    for evaluation in evaluations:
+        lines.append(f"• {evaluation.action_id} ({evaluation.action_type})")
+        for message in evaluation.messages:
+            lines.append(f"  - {message}")
+        for warning in evaluation.warnings:
+            lines.append(f"  - WARNING: {warning}")
+        for error in evaluation.errors:
+            lines.append(f"  - ERROR: {error}")
+    return lines
+
+
+def run_portfolio_dry_run(
+    actions: Iterable[PlannedAction],
+    mode: str,
+) -> list[str]:
+    gateway = IBKRGateway(mode)
+    gateway.connect()
+    try:
+        cash_by_currency = gateway.get_cash_by_currency()
+        positions = gateway.get_positions()
+    finally:
+        gateway.disconnect()
+
+    snapshot = build_snapshot(cash_by_currency, positions)
+    evaluations = evaluate_actions(actions, snapshot)
+    return build_portfolio_report(snapshot, evaluations)
+
+
+def _evaluate_sell(
+    action: PlannedAction,
+    snapshot: PortfolioSnapshot,
+    evaluation: ActionEvaluation,
+) -> None:
+    position = snapshot.positions_by_symbol.get(action.symbol)
+    if not position:
+        evaluation.errors.append(f"No holdings for {action.symbol}.")
+        return
+
+    quantity_spec = normalize_quantity(action.quantity)
+    if quantity_spec is None:
+        evaluation.errors.append("Sell action missing quantity.")
+        return
+
+    required_qty = _resolve_quantity(quantity_spec, position.quantity)
+    if required_qty is None:
+        evaluation.errors.append("Unable to resolve sell quantity.")
+        return
+
+    if required_qty > position.quantity:
+        evaluation.errors.append(
+            f"Requested {required_qty} shares exceeds holding of {position.quantity}."
+        )
+    else:
+        evaluation.messages.append(
+            f"Sell {required_qty} shares from {position.quantity} held."
+        )
+
+    if position.price is None:
+        evaluation.warnings.append("Unable to determine price for sell valuation.")
+    else:
+        evaluation.messages.append(
+            f"Estimated proceeds: {required_qty * position.price:,.2f} {position.currency}."
+        )
+
+
+def _evaluate_buy(
+    action: PlannedAction,
+    snapshot: PortfolioSnapshot,
+    evaluation: ActionEvaluation,
+) -> None:
+    quantity_spec = normalize_quantity(action.quantity)
+    if quantity_spec is None:
+        evaluation.errors.append("Buy action missing quantity.")
+        return
+
+    available_value = Decimal("0")
+    missing_sources: list[str] = []
+    unresolved_sources: list[str] = []
+
+    for source, source_type in action.using_classified or []:
+        if source_type == "cash":
+            available_value += snapshot.total_cash
+        elif source_type == "holding":
+            position = snapshot.positions_by_symbol.get(source)
+            if position:
+                available_value += position.market_value
+            else:
+                missing_sources.append(source)
+        elif source_type == "action":
+            unresolved_sources.append(source)
+
+    if missing_sources:
+        evaluation.errors.append(
+            "Missing holdings for sources: " + ", ".join(missing_sources)
+        )
+
+    if unresolved_sources:
+        evaluation.warnings.append(
+            "Cannot value action sources yet: " + ", ".join(unresolved_sources)
+        )
+
+    evaluation.messages.append(
+        f"Available value from sources: {available_value:,.2f}."
+    )
+
+    price = None
+    position = snapshot.positions_by_symbol.get(action.symbol)
+    if position:
+        price = position.price
+
+    required_value, required_shares = _resolve_buy_requirements(
+        quantity_spec, available_value, price
+    )
+
+    if required_value is not None:
+        evaluation.messages.append(
+            f"Estimated spend: {required_value:,.2f}."
+        )
+        if required_value > available_value:
+            evaluation.errors.append(
+                "Insufficient value to satisfy buy quantity."
+            )
+
+    if required_shares is not None:
+        evaluation.messages.append(
+            f"Estimated shares: {required_shares}."
+        )
+    elif price is None:
+        evaluation.warnings.append(
+            "Unable to estimate shares without a market price."
+        )
+
+
+def _evaluate_target(
+    action: PlannedAction,
+    snapshot: PortfolioSnapshot,
+    evaluation: ActionEvaluation,
+) -> None:
+    if action.percent is None:
+        evaluation.errors.append("Target action missing percent.")
+        return
+
+    percent = _coerce_decimal(action.percent) / Decimal("100")
+    total_value = Decimal("0")
+    missing_sources: list[str] = []
+    invalid_sources: list[str] = []
+
+    for source, source_type in action.using_classified or []:
+        if source_type == "cash":
+            total_value += snapshot.total_cash
+        elif source_type == "holding":
+            position = snapshot.positions_by_symbol.get(source)
+            if position:
+                total_value += position.market_value
+            else:
+                missing_sources.append(source)
+        else:
+            invalid_sources.append(source)
+
+    if missing_sources:
+        evaluation.errors.append(
+            "Missing holdings for sources: " + ", ".join(missing_sources)
+        )
+    if invalid_sources:
+        evaluation.errors.append(
+            "Targets cannot depend on actions: " + ", ".join(invalid_sources)
+        )
+
+    desired_value = total_value * percent
+    current_position = snapshot.positions_by_symbol.get(action.symbol)
+    current_value = current_position.market_value if current_position else Decimal("0")
+    delta = desired_value - current_value
+
+    evaluation.messages.append(
+        f"Target value: {desired_value:,.2f}; current value: {current_value:,.2f}."
+    )
+
+    price = current_position.price if current_position else None
+    if price:
+        shares = delta / price
+        direction = "buy" if delta > 0 else "sell"
+        evaluation.messages.append(
+            f"Implied {direction} of {shares:.4f} shares."
+        )
+    else:
+        evaluation.warnings.append(
+            "Unable to estimate target shares without a market price."
+        )
+
+
+def _resolve_quantity(
+    quantity_spec: QuantitySpec,
+    available_qty: Decimal,
+) -> Optional[Decimal]:
+    if quantity_spec.kind == "all":
+        return available_qty
+    if quantity_spec.kind == "shares" and quantity_spec.value is not None:
+        return quantity_spec.value
+    if quantity_spec.kind == "percent" and quantity_spec.value is not None:
+        return available_qty * quantity_spec.value
+    return None
+
+
+def _resolve_buy_requirements(
+    quantity_spec: QuantitySpec,
+    available_value: Decimal,
+    price: Optional[Decimal],
+) -> tuple[Optional[Decimal], Optional[Decimal]]:
+    if quantity_spec.kind == "all":
+        if price is None:
+            return available_value, None
+        return available_value, available_value / price
+    if quantity_spec.kind == "percent" and quantity_spec.value is not None:
+        required_value = available_value * quantity_spec.value
+        if price is None:
+            return required_value, None
+        return required_value, required_value / price
+    if quantity_spec.kind == "shares" and quantity_spec.value is not None:
+        if price is None:
+            return None, quantity_spec.value
+        return quantity_spec.value * price, quantity_spec.value
+    return None, None
+
+
+def _coerce_decimal(value: object) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"Invalid numeric value: {value}") from exc

--- a/tol/cli/handlers/run.py
+++ b/tol/cli/handlers/run.py
@@ -3,10 +3,9 @@ from pathlib import Path
 
 
 def handle_run(args) -> None:
-    import yaml
-
     from tol.parser.dag import compute_execution_levels
     from tol.parser.planner import plan_actions
+    from tol.load import load_tol
 
     tol_file: Path = args.tol_file
     mode = args.mode
@@ -76,10 +75,19 @@ def handle_run(args) -> None:
     print("Derived execution plan:")
     print("-" * 20)
 
-    with tol_file.open("r", encoding="utf-8") as file_handle:
-        tol_doc = yaml.safe_load(file_handle)
-
+    tol_doc = load_tol(tol_file)
     actions = plan_actions(tol_doc)
+
+    if dry_run == "portfolio":
+        from tol.cli.handlers.portfolio_dry_run import run_portfolio_dry_run
+
+        print()
+        print("Portfolio dry run:")
+        print("-" * 20)
+        report_lines = run_portfolio_dry_run(actions, mode)
+        for line in report_lines:
+            print(line)
+        print()
 
     for action in actions:
         print(f"• {action.derived_id}")

--- a/tol/load.py
+++ b/tol/load.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import json
+
+
+def load_tol(path: Path) -> dict[str, Any]:
+    tol_doc = _read_tol_file(path)
+
+    if not tol_doc:
+        return {}
+
+    actions = tol_doc.get("actions")
+    if isinstance(actions, list):
+        tol_doc["actions"] = [_normalize_action(action) for action in actions]
+
+    return tol_doc
+
+
+def _normalize_action(action: dict[str, Any]) -> dict[str, Any]:
+    if len(action) != 1:
+        return action
+
+    action_type, body = next(iter(action.items()))
+    if not isinstance(body, dict):
+        return action
+
+    if "quantity" in body or "percent" in body:
+        body = dict(body)
+        if "quantity" in body:
+            body["quantity"] = _normalize_quantity(body["quantity"])
+        if "percent" in body:
+            body["percent"] = _normalize_percent(body["percent"])
+
+    return {action_type: body}
+
+
+def _normalize_quantity(value: Any) -> Any:
+    if value is None:
+        return value
+    if isinstance(value, bool):
+        raise ValueError("Quantity must be numeric or string, not boolean.")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value > 1.0:
+            raise ValueError("Float quantity must be <= 1.0 for percentage values.")
+        return value
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            raise ValueError("Quantity string cannot be empty.")
+        upper = raw.upper()
+        if upper == "ALL":
+            return 1.0
+        if upper.endswith("%"):
+            number = upper[:-1].strip()
+            if not number:
+                raise ValueError("Percent quantity is missing a value.")
+            percent = float(number) / 100.0
+            if percent > 1.0:
+                raise ValueError("Percent quantity must be <= 100%.")
+            return percent
+        try:
+            return int(upper)
+        except ValueError as exc:
+            raise ValueError(
+                f"Quantity string must be ALL, percent, or integer: {value}"
+            ) from exc
+    return value
+
+
+def _normalize_percent(value: Any) -> Any:
+    if value is None:
+        return value
+    if isinstance(value, bool):
+        raise ValueError("Percent must be numeric or string, not boolean.")
+    if isinstance(value, (int, float)):
+        if float(value) > 100:
+            raise ValueError("Percent must be <= 100.")
+        return float(value)
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            raise ValueError("Percent string cannot be empty.")
+        upper = raw.upper()
+        if upper.endswith("%"):
+            number = upper[:-1].strip()
+            if not number:
+                raise ValueError("Percent string is missing a value.")
+            percent = float(number)
+            if percent > 100:
+                raise ValueError("Percent must be <= 100.")
+            return percent
+        try:
+            percent = float(upper)
+            if percent > 100:
+                raise ValueError("Percent must be <= 100.")
+            return percent
+        except ValueError as exc:
+            raise ValueError(
+                f"Percent string must be numeric or percent: {value}"
+            ) from exc
+    return value
+
+
+def _read_tol_file(path: Path) -> dict[str, Any]:
+    try:
+        import yaml
+    except ModuleNotFoundError:
+        yaml = None
+
+    with path.open("r", encoding="utf-8") as file_handle:
+        if yaml is not None:
+            return yaml.safe_load(file_handle)
+        return json.load(file_handle)


### PR DESCRIPTION
### Motivation
- Ensure the TOL loader accepts and normalizes `percent` fields (including strings like `"25%"`) and validates percent inputs so parsing target strings doesn't raise exceptions.

### Description
- Added handling for `percent` in `_normalize_action` and implemented `_normalize_percent(value: Any)` to accept numeric and percent-suffixed strings, reject booleans and out-of-range (>100) values, and return a normalized `float`, and added a unit test to verify parsing of `"<n>%"` target strings.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_load.py` and the suite passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69780987ee6c8321977ecf934d066455)