### PR TITLE
Scope buy-side cash to symbol currency and warn on multi-currency ambiguity

### DIFF
--- a/tests/test_portfolio_dry_run.py
+++ b/tests/test_portfolio_dry_run.py
@@ -73,6 +73,34 @@ class TestPortfolioDryRun(unittest.TestCase):
             any("Estimated spend" in msg for msg in evaluations[0].messages)
         )
 
+    def test_buy_uses_matching_currency_cash(self) -> None:
+        tol_doc = {
+            "actions": [
+                {"buy": {"symbol": "TSLA", "quantity": 1.0, "using": ["CASH"]}},
+            ]
+        }
+        actions = plan_actions(tol_doc)
+        snapshot = build_snapshot(
+            {"USD": Decimal("100"), "AUD": Decimal("200")},
+            [
+                {
+                    "symbol": "TSLA",
+                    "quantity": Decimal("10"),
+                    "market_value": Decimal("1000"),
+                    "currency": "USD",
+                }
+            ],
+        )
+
+        evaluations = evaluate_actions(actions, snapshot)
+        self.assertTrue(
+            any(
+                "Available value from sources: 100.00." in msg
+                for msg in evaluations[0].messages
+            )
+        )
+        self.assertTrue(evaluations[0].warnings)
+
     def test_target_implied_buy(self) -> None:
         tol_doc = {
             "actions": [

--- a/tol/cli/handlers/portfolio_dry_run.py
+++ b/tol/cli/handlers/portfolio_dry_run.py
@@ -215,10 +215,16 @@ def _evaluate_buy(
     available_value = Decimal("0")
     missing_sources: list[str] = []
     unresolved_sources: list[str] = []
+    expected_currency = _resolve_expected_currency(action, snapshot)
+    cash_warning_emitted = False
 
     for source, source_type in action.using_classified or []:
         if source_type == "cash":
-            available_value += snapshot.total_cash
+            cash_value, warning = _resolve_cash_value(snapshot, expected_currency)
+            available_value += cash_value
+            if warning and not cash_warning_emitted:
+                evaluation.warnings.append(warning)
+                cash_warning_emitted = True
         elif source_type == "holding":
             position = snapshot.positions_by_symbol.get(source)
             if position:
@@ -366,3 +372,33 @@ def _coerce_decimal(value: object) -> Decimal:
         return Decimal(str(value))
     except (InvalidOperation, ValueError) as exc:
         raise ValueError(f"Invalid numeric value: {value}") from exc
+
+
+def _resolve_expected_currency(
+    action: PlannedAction,
+    snapshot: PortfolioSnapshot,
+) -> Optional[str]:
+    position = snapshot.positions_by_symbol.get(action.symbol)
+    if position:
+        return position.currency
+    if len(snapshot.cash_by_currency) == 1:
+        return next(iter(snapshot.cash_by_currency.keys()))
+    return None
+
+
+def _resolve_cash_value(
+    snapshot: PortfolioSnapshot,
+    expected_currency: Optional[str],
+) -> tuple[Decimal, Optional[str]]:
+    if expected_currency is None:
+        return snapshot.total_cash, (
+            "Using total cash across currencies; no conversion applied."
+        )
+    cash_value = snapshot.cash_by_currency.get(expected_currency, Decimal("0"))
+    if len(snapshot.cash_by_currency) > 1:
+        warning = (
+            f"Using cash in {expected_currency} only; other currencies are ignored."
+        )
+    else:
+        warning = None
+    return cash_value, warning


### PR DESCRIPTION
### Motivation
- Prevent buy evaluations from overstating available funds in multi-currency portfolios by avoiding blind summation of all cash balances. 
- Make insufficient-funds conditions clearer by valuing `CASH` in the currency relevant to the target symbol and emitting warnings when other currencies are ignored or when no symbol currency can be inferred.

### Description
- Change buy evaluation in `tol/cli/handlers/portfolio_dry_run.py` to resolve an expected currency for the action and use helpers to compute the cash value in that currency instead of always using `snapshot.total_cash`.
- Add helper functions `
_resolve_expected_currency` and `_resolve_cash_value` to return the cash amount to use and an optional warning message, and add a `cash_warning_emitted` guard to avoid duplicate warnings.
- Emit a warning when total cash across currencies is used without conversion or when only one currency is chosen and others are ignored.
- Add unit test `test_buy_uses_matching_currency_cash` in `tests/test_portfolio_dry_run.py` to cover multi-currency cash handling.

### Testing
- Ran `python -m pytest tests/test_portfolio_dry_run.py` and all tests passed (5 passed).
- New test verifies that a buy for a USD-denominated symbol only counts USD cash and that a warning is emitted when other currencies are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697832deaea08321b4ab23e9b9442265)