### PR TITLE
Parse percent and quantity values in planner

### DIFF
--- a/tests/test_ibkr_gateway.py
+++ b/tests/test_ibkr_gateway.py
@@ -1,0 +1,89 @@
+import unittest
+
+from tol.ibkr.gateway import BrokerDryRunResult, IBKRGateway
+from tol.parser.planner import PlannedAction
+
+
+class StubIB:
+    def __init__(self, resolvable_symbols: set[str]) -> None:
+        self.resolvable_symbols = resolvable_symbols
+
+    def qualifyContracts(self, contract):
+        if contract.symbol in self.resolvable_symbols:
+            return [contract]
+        return []
+
+
+class TestIBKRGateway(unittest.TestCase):
+    def test_normalize_symbol(self) -> None:
+        self.assertEqual(IBKRGateway.normalize_symbol(" aapl "), "AAPL")
+
+        with self.assertRaises(ValueError):
+            IBKRGateway.normalize_symbol(None)
+
+        with self.assertRaises(ValueError):
+            IBKRGateway.normalize_symbol(" ")
+
+        with self.assertRaises(ValueError):
+            IBKRGateway.normalize_symbol("BRK.B")
+
+    def test_broker_dry_run(self) -> None:
+        gateway = IBKRGateway("paper")
+        gateway.ib = StubIB({"AAPL"})
+
+        actions = [
+            PlannedAction(
+                index=0,
+                action_type="buy",
+                symbol="AAPL",
+                quantity="10",
+                derived_id="buyAAPL",
+                depends_on=[],
+            ),
+            PlannedAction(
+                index=1,
+                action_type="buy",
+                symbol="msft",
+                quantity="5",
+                derived_id="buyMSFT",
+                depends_on=[],
+            ),
+            PlannedAction(
+                index=2,
+                action_type="buy",
+                symbol="bad.symbol",
+                quantity="1",
+                derived_id="buyBAD",
+                depends_on=[],
+            ),
+        ]
+
+        results = gateway.broker_dry_run(actions)
+        self.assertEqual(len(results), 3)
+
+        expected = [
+            BrokerDryRunResult(
+                action_id="buyAAPL",
+                symbol="AAPL",
+                status="ok",
+                details="Contract resolved.",
+            ),
+            BrokerDryRunResult(
+                action_id="buyMSFT",
+                symbol="MSFT",
+                status="unresolved_contract",
+                details="No matching contract found.",
+            ),
+            BrokerDryRunResult(
+                action_id="buyBAD",
+                symbol="bad.symbol",
+                status="invalid_symbol",
+                details="Symbol must be alphanumeric",
+            ),
+        ]
+
+        self.assertEqual(results, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_planner_parsing.py
+++ b/tests/test_planner_parsing.py
@@ -1,0 +1,41 @@
+import unittest
+from decimal import Decimal
+
+from tol.parser.planner import ParsedQuantity, parse_percent, parse_quantity
+
+
+class TestPlannerParsing(unittest.TestCase):
+    def test_parse_percent(self) -> None:
+        self.assertEqual(parse_percent(10), Decimal("10"))
+        self.assertEqual(parse_percent("10%"), Decimal("10"))
+        self.assertEqual(parse_percent(" 12.5 "), Decimal("12.5"))
+
+        with self.assertRaises(ValueError):
+            parse_percent("")
+
+        with self.assertRaises(ValueError):
+            parse_percent("abc")
+
+    def test_parse_quantity(self) -> None:
+        self.assertEqual(
+            parse_quantity(10),
+            ParsedQuantity(kind="shares", value=Decimal("10")),
+        )
+        self.assertEqual(
+            parse_quantity("10%"),
+            ParsedQuantity(kind="percent", value=Decimal("10")),
+        )
+        self.assertEqual(
+            parse_quantity("ALL"),
+            ParsedQuantity(kind="all", value=None),
+        )
+
+        with self.assertRaises(ValueError):
+            parse_quantity("")
+
+        with self.assertRaises(ValueError):
+            parse_quantity("oops")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tol/ibkr/gateway.py
+++ b/tol/ibkr/gateway.py
@@ -1,6 +1,19 @@
+from dataclasses import dataclass
 from decimal import Decimal
 from collections import defaultdict
-from ib_insync import IB
+from typing import Iterable, List
+
+from ib_insync import IB, Stock
+
+from tol.parser.planner import PlannedAction
+
+
+@dataclass(frozen=True)
+class BrokerDryRunResult:
+    action_id: str
+    symbol: str
+    status: str
+    details: str | None = None
 
 
 class IBKRGateway:
@@ -43,5 +56,59 @@ class IBKRGateway:
             })
 
         return results
+
+    @staticmethod
+    def normalize_symbol(symbol: str) -> str:
+        if symbol is None:
+            raise ValueError("Symbol cannot be None")
+
+        normalized = symbol.strip().upper()
+        if not normalized:
+            raise ValueError("Symbol cannot be empty")
+        if not normalized.isalnum():
+            raise ValueError("Symbol must be alphanumeric")
+
+        return normalized
+
+    def broker_dry_run(
+        self, actions: Iterable[PlannedAction]
+    ) -> List[BrokerDryRunResult]:
+        results: List[BrokerDryRunResult] = []
+
+        for action in actions:
+            try:
+                symbol = self.normalize_symbol(action.symbol)
+            except ValueError as exc:
+                results.append(
+                    BrokerDryRunResult(
+                        action_id=action.derived_id,
+                        symbol=action.symbol,
+                        status="invalid_symbol",
+                        details=str(exc),
+                    )
+                )
+                continue
+
+            contract = Stock(symbol, "SMART", "USD")
+            qualified = self.ib.qualifyContracts(contract)
+            if not qualified:
+                results.append(
+                    BrokerDryRunResult(
+                        action_id=action.derived_id,
+                        symbol=symbol,
+                        status="unresolved_contract",
+                        details="No matching contract found.",
+                    )
+                )
+                continue
+
+            results.append(
+                BrokerDryRunResult(
+                    action_id=action.derived_id,
+                    symbol=symbol,
+                    status="ok",
+                    details="Contract resolved.",
+                )
+            )
 
         return results

--- a/tol/parser/planner.py
+++ b/tol/parser/planner.py
@@ -1,5 +1,19 @@
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from typing import List, Optional, Tuple, Set
+
+
+@dataclass(frozen=True)
+class ParsedQuantity:
+    kind: str
+    value: Decimal | None = None
+
+    def __str__(self) -> str:
+        if self.kind == "all":
+            return "ALL"
+        if self.kind == "percent":
+            return f"{self.value}%"
+        return f"{self.value}"
 
 
 @dataclass
@@ -7,8 +21,8 @@ class PlannedAction:
     index: int
     action_type: str
     symbol: str
-    quantity: Optional[str] = None
-    percent: Optional[float] = None
+    quantity: Optional[ParsedQuantity] = None
+    percent: Optional[Decimal] = None
     using: List[str] = None
     using_classified: List[Tuple[str, str]] = None
     derived_id: str = ""
@@ -17,6 +31,54 @@ class PlannedAction:
 
 def derive_action_id(action_type: str, symbol: str) -> str:
     return f"{action_type}{symbol.upper()}"
+
+
+def parse_percent(value) -> Optional[Decimal]:
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float, Decimal)):
+        return Decimal(str(value))
+
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.endswith("%"):
+            stripped = stripped[:-1].strip()
+        if not stripped:
+            raise ValueError("Percent cannot be empty")
+        try:
+            return Decimal(stripped)
+        except InvalidOperation as exc:
+            raise ValueError(f"Invalid percent value: {value}") from exc
+
+    raise ValueError(f"Unsupported percent value type: {type(value)}")
+
+
+def parse_quantity(value) -> Optional[ParsedQuantity]:
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float, Decimal)):
+        return ParsedQuantity(kind="shares", value=Decimal(str(value)))
+
+    if isinstance(value, str):
+        stripped = value.strip().upper()
+        if stripped == "ALL":
+            return ParsedQuantity(kind="all")
+        if stripped.endswith("%"):
+            stripped = stripped[:-1].strip()
+            if not stripped:
+                raise ValueError("Quantity percent cannot be empty")
+            try:
+                return ParsedQuantity(kind="percent", value=Decimal(stripped))
+            except InvalidOperation as exc:
+                raise ValueError(f"Invalid percent quantity: {value}") from exc
+        try:
+            return ParsedQuantity(kind="shares", value=Decimal(stripped))
+        except InvalidOperation as exc:
+            raise ValueError(f"Invalid quantity value: {value}") from exc
+
+    raise ValueError(f"Unsupported quantity value type: {type(value)}")
 
 
 def plan_actions(tol_doc: dict) -> List[PlannedAction]:
@@ -51,8 +113,8 @@ def plan_actions(tol_doc: dict) -> List[PlannedAction]:
             index=idx,
             action_type=action_type,
             symbol=symbol,
-            quantity=body.get("quantity"),
-            percent=body.get("percent"),
+            quantity=parse_quantity(body.get("quantity")),
+            percent=parse_percent(body.get("percent")),
             using=using,
             derived_id=derived_id,
             depends_on=[]


### PR DESCRIPTION
### Motivation
- Ensure action `quantity` and `percent` values are normalized and validated so downstream code (planners, gateways, and order logic) can rely on a structured representation.
- Support percent strings (e.g. `"10%"`), numeric inputs, and special quantity keywords like `ALL` while surfacing clear errors for malformed inputs.
- Use `Decimal` for numeric precision when working with percentages and share amounts.

### Description
- Add a frozen dataclass `ParsedQuantity` to represent normalized quantities with `kind` (`shares`, `percent`, `all`) and an optional `Decimal` value, and implement a user-friendly `__str__`.
- Add `parse_percent(value)` that normalizes ints/floats/`Decimal` and percent strings into `Decimal`, validating and raising `ValueError` on invalid inputs.
- Add `parse_quantity(value)` that returns a `ParsedQuantity` from ints/floats/`Decimal`, percent strings (e.g. `"10%"`), the `ALL` keyword, or numeric share strings, raising `ValueError` for bad inputs.
- Update `PlannedAction` type hints to use `ParsedQuantity` and `Decimal` and update `plan_actions` to call `parse_quantity` and `parse_percent` when building actions.
- Add unit tests in `tests/test_planner_parsing.py` covering valid and invalid percent/quantity inputs.

### Testing
- Ran `python -m unittest discover -s tests` which executed the test suite and completed successfully (`OK`).
- Added and executed `tests/test_planner_parsing.py`, which verifies `parse_percent` and `parse_quantity` behavior and passed.
- Existing test suite remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69780a7b50e08321bd052d026586be65)