### PR TITLE
Broker dry-run validation, IBKR what-if support, and test import fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pathlib
+import sys
+
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_broker_dry_run.py
+++ b/tests/test_broker_dry_run.py
@@ -1,0 +1,102 @@
+from decimal import Decimal
+import unittest
+
+from tol.cli.handlers.broker_dry_run import (
+    run_broker_dry_run,
+    validate_action_with_broker,
+)
+from tol.parser.planner import plan_actions
+
+
+class FakeGateway:
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        self.connected = False
+        self.disconnected = False
+
+    def connect(self) -> None:
+        self.connected = True
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+    def qualify_stock_contract(
+        self,
+        symbol: str,
+        currency: str = "USD",
+        exchange: str = "SMART",
+    ):
+        if symbol == "BAD":
+            return None
+        return {"symbol": symbol, "currency": currency, "exchange": exchange}
+
+    def validate_order(
+        self,
+        contract: object,
+        action_type: str,
+        quantity: Decimal,
+    ) -> dict:
+        return {"status": "Validated"}
+
+
+class TestBrokerDryRun(unittest.TestCase):
+    def test_validate_buy_action(self) -> None:
+        tol_doc = {
+            "actions": [
+                {"buy": {"symbol": "AAPL", "quantity": 5}},
+            ]
+        }
+        actions = plan_actions(tol_doc)
+        validation = validate_action_with_broker(actions[0], FakeGateway("paper"))
+
+        self.assertFalse(validation.errors)
+        self.assertTrue(
+            any("Resolved contract" in msg for msg in validation.messages)
+        )
+        self.assertTrue(
+            any("Broker validation status" in msg for msg in validation.messages)
+        )
+
+    def test_validate_symbol_failure(self) -> None:
+        tol_doc = {
+            "actions": [
+                {"buy": {"symbol": "BAD", "quantity": 1}},
+            ]
+        }
+        actions = plan_actions(tol_doc)
+        validation = validate_action_with_broker(actions[0], FakeGateway("paper"))
+
+        self.assertTrue(validation.errors)
+
+    def test_percent_quantity_warns(self) -> None:
+        tol_doc = {
+            "actions": [
+                {"sell": {"symbol": "AAPL", "quantity": "50%"}},
+            ]
+        }
+        actions = plan_actions(tol_doc)
+        validation = validate_action_with_broker(actions[0], FakeGateway("paper"))
+
+        self.assertTrue(validation.warnings)
+        self.assertFalse(validation.errors)
+
+    def test_run_broker_dry_run_disconnects(self) -> None:
+        tol_doc = {
+            "actions": [
+                {"buy": {"symbol": "AAPL", "quantity": 1}},
+            ]
+        }
+        actions = plan_actions(tol_doc)
+        gateway = FakeGateway("paper")
+
+        def factory(_: str) -> FakeGateway:
+            return gateway
+
+        run_broker_dry_run(actions, "paper", gateway_factory=factory)
+
+        self.assertTrue(gateway.connected)
+        self.assertTrue(gateway.disconnected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tol/__init__.py
+++ b/tol/__init__.py
@@ -1,0 +1,1 @@
+"""Trading Orchestration Language package."""

--- a/tol/cli/handlers/broker_dry_run.py
+++ b/tol/cli/handlers/broker_dry_run.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Callable, Iterable, Optional, Protocol
+
+from tol.ibkr.gateway import IBKRGateway
+from tol.parser.planner import PlannedAction
+
+
+class BrokerGateway(Protocol):
+    def connect(self) -> None: ...
+
+    def disconnect(self) -> None: ...
+
+    def qualify_stock_contract(
+        self,
+        symbol: str,
+        currency: str = "USD",
+        exchange: str = "SMART",
+    ) -> object: ...
+
+    def validate_order(
+        self,
+        contract: object,
+        action_type: str,
+        quantity: Decimal,
+    ) -> dict: ...
+
+
+@dataclass
+class BrokerValidation:
+    action_id: str
+    action_type: str
+    symbol: str
+    messages: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def run_broker_dry_run(
+    actions: Iterable[PlannedAction],
+    mode: str,
+    gateway_factory: Callable[[str], BrokerGateway] = IBKRGateway,
+) -> list[str]:
+    gateway = gateway_factory(mode)
+    gateway.connect()
+    try:
+        results = [validate_action_with_broker(action, gateway) for action in actions]
+    finally:
+        gateway.disconnect()
+    return build_broker_report(results)
+
+
+def build_broker_report(
+    results: Iterable[BrokerValidation],
+) -> list[str]:
+    lines: list[str] = []
+    lines.append("Broker dry run evaluation:")
+    for result in results:
+        lines.append(f"• {result.action_id} ({result.action_type})")
+        for message in result.messages:
+            lines.append(f"  - {message}")
+        for warning in result.warnings:
+            lines.append(f"  - WARNING: {warning}")
+        for error in result.errors:
+            lines.append(f"  - ERROR: {error}")
+    return lines
+
+
+def validate_action_with_broker(
+    action: PlannedAction,
+    gateway: BrokerGateway,
+) -> BrokerValidation:
+    validation = BrokerValidation(
+        action_id=action.derived_id,
+        action_type=action.action_type,
+        symbol=action.symbol,
+    )
+
+    sanitized_symbol = _sanitize_symbol(action.symbol, validation)
+    if sanitized_symbol is None:
+        return validation
+
+    contract = _resolve_contract(gateway, sanitized_symbol, validation)
+    if contract is None:
+        return validation
+
+    if action.action_type in {"buy", "sell"}:
+        quantity = _resolve_share_quantity(action.quantity, validation)
+        if quantity is None:
+            return validation
+        _validate_order_with_gateway(
+            gateway,
+            contract,
+            action.action_type,
+            quantity,
+            validation,
+        )
+    elif action.action_type == "target":
+        validation.warnings.append(
+            "Target actions require portfolio context to derive shares."
+        )
+    else:
+        validation.warnings.append(
+            f"Unknown action type '{action.action_type}'."
+        )
+
+    return validation
+
+
+def _sanitize_symbol(
+    symbol: object,
+    validation: BrokerValidation,
+) -> Optional[str]:
+    if not isinstance(symbol, str):
+        validation.errors.append("Symbol must be a string.")
+        return None
+    sanitized = symbol.strip().upper()
+    if not sanitized:
+        validation.errors.append("Symbol cannot be empty.")
+        return None
+    return sanitized
+
+
+def _resolve_contract(
+    gateway: BrokerGateway,
+    symbol: str,
+    validation: BrokerValidation,
+) -> Optional[object]:
+    try:
+        contract = gateway.qualify_stock_contract(symbol)
+    except Exception as exc:  # pragma: no cover - defensive for broker errors
+        validation.errors.append(f"Failed to resolve contract: {exc}.")
+        return None
+    if not contract:
+        validation.errors.append("Unable to resolve broker contract.")
+        return None
+    validation.messages.append(f"Resolved contract for {symbol}.")
+    return contract
+
+
+def _resolve_share_quantity(
+    quantity: object,
+    validation: BrokerValidation,
+) -> Optional[Decimal]:
+    if quantity is None:
+        validation.errors.append("Order quantity is required for broker validation.")
+        return None
+    if isinstance(quantity, (int, Decimal)):
+        return _coerce_decimal(quantity, validation)
+    if isinstance(quantity, float):
+        validation.warnings.append(
+            "Float quantity interpreted as percent; broker validation skipped."
+        )
+        return None
+    if isinstance(quantity, str):
+        raw = quantity.strip().upper()
+        if raw == "ALL" or raw.endswith("%"):
+            validation.warnings.append(
+                "Percent/ALL quantities need portfolio context; "
+                "broker validation skipped."
+            )
+            return None
+        return _coerce_decimal(raw, validation)
+    validation.errors.append("Unsupported quantity type.")
+    return None
+
+
+def _coerce_decimal(
+    value: object,
+    validation: BrokerValidation,
+) -> Optional[Decimal]:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        validation.errors.append(f"Invalid numeric value: {value}.")
+        return None
+
+
+def _validate_order_with_gateway(
+    gateway: BrokerGateway,
+    contract: object,
+    action_type: str,
+    quantity: Decimal,
+    validation: BrokerValidation,
+) -> None:
+    if quantity <= 0:
+        validation.errors.append("Order quantity must be positive.")
+        return
+    try:
+        result = gateway.validate_order(contract, action_type, quantity)
+    except Exception as exc:  # pragma: no cover - broker issues
+        validation.errors.append(f"Broker validation failed: {exc}.")
+        return
+
+    status = result.get("status") if isinstance(result, dict) else None
+    if status:
+        validation.messages.append(f"Broker validation status: {status}.")
+    else:
+        validation.messages.append("Broker validation completed.")

--- a/tol/cli/handlers/run.py
+++ b/tol/cli/handlers/run.py
@@ -88,6 +88,16 @@ def handle_run(args) -> None:
         for line in report_lines:
             print(line)
         print()
+    elif dry_run == "broker":
+        from tol.cli.handlers.broker_dry_run import run_broker_dry_run
+
+        print()
+        print("Broker dry run:")
+        print("-" * 20)
+        report_lines = run_broker_dry_run(actions, mode)
+        for line in report_lines:
+            print(line)
+        print()
 
     for action in actions:
         print(f"• {action.derived_id}")

--- a/tol/ibkr/gateway.py
+++ b/tol/ibkr/gateway.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 from collections import defaultdict
-from ib_insync import IB
+from ib_insync import IB, MarketOrder, Stock
 
 
 class IBKRGateway:
@@ -43,3 +43,27 @@ class IBKRGateway:
             })
 
         return results
+
+    def qualify_stock_contract(
+        self,
+        symbol: str,
+        currency: str = "USD",
+        exchange: str = "SMART",
+    ):
+        contract = Stock(symbol, exchange, currency)
+        contracts = self.ib.qualifyContracts(contract)
+        if not contracts:
+            return None
+        return contracts[0]
+
+    def validate_order(
+        self,
+        contract,
+        action_type: str,
+        quantity: Decimal,
+    ) -> dict:
+        side = "BUY" if action_type == "buy" else "SELL"
+        order = MarketOrder(side, float(quantity))
+        order_state = self.ib.whatIfOrder(contract, order)
+        status = getattr(order_state, "status", None)
+        return {"status": status}


### PR DESCRIPTION
### Motivation
- Provide a broker-level dry-run that resolves stock contracts and validates order parameters against IBKR without placing live orders.  
- Surface deterministic broker validation feedback in the CLI so users can detect contract/ordering issues before execution.  
- Fix test import/runtime issues so the test-suite can import the `tol` package reliably.

### Description
- Add `tol/cli/handlers/broker_dry_run.py` implementing `run_broker_dry_run`, `validate_action_with_broker`, symbol sanitization (`_sanitize_symbol`), contract resolution (`_resolve_contract`), quantity normalization (`_resolve_share_quantity` / `_coerce_decimal`), and gateway order validation (`_validate_order_with_gateway`).  
- Extend `tol/ibkr/gateway.py` with `qualify_stock_contract` and `validate_order` which use `ib_insync.Stock`, `MarketOrder`, and `whatIfOrder` to qualify contracts and obtain validation status.  
- Wire broker dry-run into the CLI by updating `tol/cli/handlers/run.py` to call `run_broker_dry_run` when `--dry-run broker` is selected.  
- Add tests: `tests/test_broker_dry_run.py` exercises contract resolution paths, percent/ALL warnings, gateway lifecycle via a `FakeGateway`, and the broker validation messaging; add `tests/conftest.py` to ensure project root is on `sys.path`; add `tol/__init__.py` so `tol` is importable in tests.

### Testing
- Added unit tests for broker dry-run behavior in `tests/test_broker_dry_run.py`.  
- Ran the full test-suite with `pytest -q` and all tests passed: `17 passed`.  
- Import issues during collection were resolved by `tests/conftest.py` and `tol/__init__.py`, enabling successful test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783678b8a08321b858f82f5bb1c72c)