### PR TITLE
Support filling multiple FakeBroker order IDs

### DIFF
--- a/fakebroker/cli/handlers/fakebroker.py
+++ b/fakebroker/cli/handlers/fakebroker.py
@@ -92,6 +92,17 @@ class FakeBrokerController:
         orders.sort(key=self._order_sort_key)
         return orders
 
+    def fill_orders(
+        self,
+        order_ids: list[str],
+        quantity: Decimal | None = None,
+    ) -> list[FillResult]:
+        sanitized_order_ids = self._sanitize_order_ids(order_ids)
+        results: list[FillResult] = []
+        for order_id in sanitized_order_ids:
+            results.append(self.fill_order(order_id, quantity))
+        return results
+
     def fill_order(self, order_id: str, quantity: Decimal | None = None) -> FillResult:
         state = self._state.load()
         orders = state.get("orders", {})
@@ -332,6 +343,13 @@ class FakeBrokerController:
             return value
         return Decimal(str(value).replace(",", "").strip())
 
+    @staticmethod
+    def _sanitize_order_ids(order_ids: list[str]) -> list[str]:
+        sanitized = [order_id.strip() for order_id in order_ids if order_id.strip()]
+        if not sanitized:
+            raise ValueError("At least one order id is required")
+        return sanitized
+
 
 def handle_fakebroker(args: Any) -> None:
     controller = FakeBrokerController(_resolve_state_path())
@@ -364,11 +382,12 @@ def handle_fakebroker(args: Any) -> None:
                 if args.quantity is not None
                 else None
             )
-            result = controller.fill_order(args.order_id, quantity)
-            print(
-                f"Filled {result.filled_qty} @ {result.price} {result.currency} "
-                f"for {result.order_id} ({result.status})."
-            )
+            results = controller.fill_orders(args.order_ids, quantity)
+            for result in results:
+                print(
+                    f"Filled {result.filled_qty} @ {result.price} {result.currency} "
+                    f"for {result.order_id} ({result.status})."
+                )
             return
         if args.order_command == "delete":
             deleted, missing = controller.delete_orders(args.order_ids)

--- a/fakebroker/cli/main.py
+++ b/fakebroker/cli/main.py
@@ -44,8 +44,12 @@ def build_parser() -> argparse.ArgumentParser:
     order_parser = subparsers.add_parser("order", help="Inspect or fill orders")
     order_sub = order_parser.add_subparsers(dest="order_command", required=True)
     order_sub.add_parser("list", help="List open orders")
-    order_fill = order_sub.add_parser("fill", help="Fill an order")
-    order_fill.add_argument("order_id", help="Broker order id (e.g. FB-1)")
+    order_fill = order_sub.add_parser("fill", help="Fill one or more orders")
+    order_fill.add_argument(
+        "order_ids",
+        nargs="+",
+        help="One or more broker order ids (e.g. FB-1 FB-2)",
+    )
     order_fill.add_argument(
         "--quantity",
         dest="quantity",

--- a/tests/test_fakebroker_cli.py
+++ b/tests/test_fakebroker_cli.py
@@ -98,6 +98,67 @@ def test_fakebroker_order_delete_removes_matching_ids(tmp_path):
     assert "FB-2" in updated["orders"]
 
 
+def test_fakebroker_fill_orders_supports_multiple_ids(tmp_path):
+    state_path = tmp_path / "fake_broker_state.yaml"
+    state_manager = FakeBrokerState(state_path)
+    state = state_manager.default_state()
+    state["portfolio"]["cash"]["USD"] = 10000
+    state["prices"]["NVDA.NASDAQ"] = {"price": 100, "currency": "USD"}
+    state["orders"] = {
+        "FB-1": {
+            "status": "SUBMITTED",
+            "submitted_qty": 2.0,
+            "filled_qty": 0.0,
+            "average_price": None,
+            "failure_reason": None,
+            "trade": {
+                "order_id": "FB-1",
+                "status": "SUBMITTED",
+                "filled_qty": 0.0,
+                "avg_fill_price": None,
+                "action_type": "buy",
+                "symbol": "NVDA.NASDAQ",
+                "submitted_qty": 2.0,
+                "order_type": "MKT",
+            },
+        },
+        "FB-2": {
+            "status": "SUBMITTED",
+            "submitted_qty": 3.0,
+            "filled_qty": 0.0,
+            "average_price": None,
+            "failure_reason": None,
+            "trade": {
+                "order_id": "FB-2",
+                "status": "SUBMITTED",
+                "filled_qty": 0.0,
+                "avg_fill_price": None,
+                "action_type": "buy",
+                "symbol": "NVDA.NASDAQ",
+                "submitted_qty": 3.0,
+                "order_type": "MKT",
+            },
+        },
+    }
+    state_manager.save(state)
+
+    controller = FakeBrokerController(state_path)
+    results = controller.fill_orders(["FB-1", "FB-2"])
+
+    updated = state_manager.load()
+    assert [result.order_id for result in results] == ["FB-1", "FB-2"]
+    assert updated["orders"]["FB-1"]["status"] == "FILLED"
+    assert updated["orders"]["FB-2"]["status"] == "FILLED"
+
+
+def test_fakebroker_parser_supports_order_fill_multiple_ids() -> None:
+    args = build_parser().parse_args(["order", "fill", "FB-1", "FB-2"])
+
+    assert args.command == "order"
+    assert args.order_command == "fill"
+    assert args.order_ids == ["FB-1", "FB-2"]
+
+
 def test_fakebroker_parser_supports_order_delete() -> None:
     args = build_parser().parse_args(["order", "delete", "FB-1", "FB-2"])
 


### PR DESCRIPTION
### Motivation
- Allow the `fakebroker order fill` command to fill multiple orders in a single invocation for parity with `order delete` and improved CLI convenience.
- Sanitize and validate user input for multiple order ids to avoid empty or malformed inputs.

### Description
- Updated the CLI parser to accept one or more positional `order_ids` for `order fill` instead of a single `order_id` by using `nargs='+'` in `fakebroker/cli/main.py`.
- Added `FakeBrokerController.fill_orders(...)` that sanitizes the provided IDs with a new `@staticmethod _sanitize_order_ids(...)` and calls the existing `fill_order(...)` sequentially, returning a list of per-order `FillResult` objects in `fakebroker/cli/handlers/fakebroker.py`.
- Updated the `handle_fakebroker` command handling to call `fill_orders(...)` and print a result line for each filled order.
- Added unit tests to `tests/test_fakebroker_cli.py` covering multi-ID fill behavior and parser support for multiple fill IDs.

### Testing
- Ran `pytest -q tests/test_fakebroker_cli.py` and all tests passed (`6 passed`).
- The changes were exercised by tests that verify both the parser (`order fill` accepting multiple IDs) and the controller behavior when filling multiple orders.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ad98a4a588321a780a8b4a7f3602c)